### PR TITLE
Split ArcConfiguration into 2 interfaces

### DIFF
--- a/joan-arc-portal/src/main/java/com/teslagov/joan/portal/content/publish/ItemPublisher.java
+++ b/joan-arc-portal/src/main/java/com/teslagov/joan/portal/content/publish/ItemPublisher.java
@@ -1,6 +1,5 @@
 package com.teslagov.joan.portal.content.publish;
 
-import com.teslagov.joan.core.ArcConfiguration;
 import com.teslagov.joan.core.ArcPortalConfiguration;
 import com.teslagov.joan.core.TokenResponse;
 import com.teslagov.joan.core.http.HttpExecutor;

--- a/joan-arc-portal/src/main/java/com/teslagov/joan/portal/token/PortalTokenFetcher.java
+++ b/joan-arc-portal/src/main/java/com/teslagov/joan/portal/token/PortalTokenFetcher.java
@@ -1,6 +1,5 @@
 package com.teslagov.joan.portal.token;
 
-import com.teslagov.joan.core.ArcConfiguration;
 import com.teslagov.joan.core.ArcPortalConfiguration;
 import com.teslagov.joan.core.TokenFetcher;
 import com.teslagov.joan.core.TokenResponse;

--- a/joan-arc/src/main/java/com/teslagov/joan/api/GroupApi.java
+++ b/joan-arc/src/main/java/com/teslagov/joan/api/GroupApi.java
@@ -1,6 +1,5 @@
 package com.teslagov.joan.api;
 
-import com.teslagov.joan.core.ArcConfiguration;
 import com.teslagov.joan.core.ArcPortalConfiguration;
 import com.teslagov.joan.core.TokenManager;
 import com.teslagov.joan.portal.community.group.Group;


### PR DESCRIPTION
Portal configuration and ArcGIS Server configuration are logically separate:

File now looks like:
```java
public interface ArcConfiguration {
  ArcServerConfiguration getArcServerConfiguration();
  ArcPortalConfiguration getArcPortalConfiguration();
}
```